### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 Buffer = require("buffer").Buffer;
-Parse = require("Parse").Parse;
+Parse = require("parse").Parse;
 _ = Parse._;
 Parse.Cloud = {};
 Parse.Cloud.job = Parse.Cloud.define = Parse.Cloud.beforeSave =


### PR DESCRIPTION
Shouldn't we do `require('parse')` instead of `require('Parse')`? I don't know what I am doing, really, but the installation only works if I change `Parse` to lowercase.
